### PR TITLE
Fix read.pangloss.R and encoding support for read.toolbox.R

### DIFF
--- a/R/read.pangloss.R
+++ b/R/read.pangloss.R
@@ -45,10 +45,10 @@ read.pangloss <- function(url,
     sentencesdf <- data.frame(
       sentence_id = sentence_id,
       text_id     = rep(1:length(texts), times = sentence.by.texts),
-      audio_start = xml_text(xml_find_first(texts, "/TEXT/S/AUDIO/@start")),
-      audio_end   = xml_text(xml_find_first(texts, "/TEXT/S/AUDIO/@end")),
-      form = xml_text(xml_find_first(texts, "/TEXT/S/FORM")),
-      translation = xml_text(xml_find_first(texts, "/TEXT/S/TRANSL"))
+      audio_start = xml_text(xml_find_all(texts, "/TEXT/S/AUDIO/@start")),
+      audio_end   = xml_text(xml_find_all(texts, "/TEXT/S/AUDIO/@end")),
+      form = xml_text(xml_find_all(texts, "/TEXT/S/FORM")),
+      translation = xml_text(xml_find_all(texts, "/TEXT/S/TRANSL"))
     );
     interlinearized$sentences <- sentencesdf;
   }

--- a/R/read.toolbox.R
+++ b/R/read.toolbox.R
@@ -21,9 +21,10 @@ read.toolbox <- function(path,
                          text.fields.suppl=NULL,
                          sentence.fields.suppl=c("tx", "nt", "ft"),
 												 word.fields.suppl=NULL,
-                         morpheme.fields.suppl=NULL) {
+                         morpheme.fields.suppl=NULL, 
+												 encoding = "unknown") {
  
-  lines <- readLines(path);
+  lines <- readLines(path, encoding = encoding);
 
   ## fields have mandatory elements for each level
   text.fields <- unique(c("id", text.fields.suppl));


### PR DESCRIPTION
Modify pangloss code such that sentences displays all sentences, not just the first sentence of each text.